### PR TITLE
fix: add pull request trigger

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - 'main'
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
   workflow_dispatch:
   schedule:
   - cron: "0 12 1 * *"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - 'main'
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
   schedule:
   - cron: "0 12 1 * *"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
   pull_request:
-    types: 
+    types:
       - opened
       - reopened
       - synchronize

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,12 +3,15 @@ run-name: Running tests on "${{ github.ref }}" by "${{ github.actor }}"
 on:
   push:
     branches:
-    - 'main'
+      - 'main'
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: 
+      - opened
+      - reopened
+      - synchronize
   workflow_dispatch:
   schedule:
-  - cron: "0 12 1 * *"
+    - cron: "0 12 1 * *"
 
 jobs:
   # Run pre-commit hooks

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,8 @@ name: "Continuous Integration"
 run-name: Running tests on "${{ github.ref }}" by "${{ github.actor }}"
 on:
   push:
+    branches:
+    - 'main'
   pull_request:
     types: [opened, reopened]
   workflow_dispatch:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,8 @@ name: "Continuous Integration"
 run-name: Running tests on "${{ github.ref }}" by "${{ github.actor }}"
 on:
   push:
+  pull_request:
+    types: [opened, reopened]
   workflow_dispatch:
   schedule:
   - cron: "0 12 1 * *"


### PR DESCRIPTION
# fix: Add pull request trigger to GitHub Actions
## Description
This pull request modifies the GitHub Actions workflow configurations to include pull_request as an additional event trigger.

Previously, our workflows might have only been triggered by push events (e.g., to main or other branches). This meant that automated checks (like linting, testing, or build validations) were only run after changes were merged or pushed directly, rather than during the review process.

By adding pull_request to the on: section of our workflows, we ensure that these crucial checks are executed automatically whenever a pull request is opened, synchronized, or reopened.