### PR TITLE
feat: add doc retriever

### DIFF
--- a/experiments/doc_reader.py
+++ b/experiments/doc_reader.py
@@ -5,13 +5,7 @@ from haystack import Pipeline
 from haystack.nodes import FARMReader
 # from haystack.utils import print_answers
 
-from .module import Dataset, DocReader, Sports
-from .module import (
-    SQuadDataset,
-    AdversarialQADataset,
-    DuoRCDataset,
-    QASportsDataset,
-)
+from .module import Dataset, DocReader, Sports, dataset_switch
 
 
 # Model setup
@@ -50,24 +44,8 @@ print(f"Dataset: {DATASET} // Sport: {SPORT}")
 print(f"Model: {DOC_READER}")
 
 
-# Download the dataset
-def dataset_switch(choice):
-    """Get dataset class"""
-
-    if choice == Dataset.SQuAD:
-        return SQuadDataset()
-    elif choice == Dataset.AdvQA:
-        return AdversarialQADataset()
-    elif choice == Dataset.DuoRC:
-        return DuoRCDataset()
-    elif choice == Dataset.QASports:
-        return QASportsDataset(SPORT)
-    else:
-        return "Invalid dataset"
-
-
 # Get the dataset
-dataset = dataset_switch(DATASET)
+dataset = dataset_switch(DATASET, SPORT)
 docs = dataset.get_documents()
 
 """---

--- a/experiments/doc_reader.py
+++ b/experiments/doc_reader.py
@@ -17,7 +17,7 @@ parser.add_argument(
     "--dataset",
     type=str,
     default="QASports",
-    choices=[d.name for d in Dataset],
+    choices=[attr.name for attr in Dataset],
     help="Dataset to use for the experiment.",
 )
 parser.add_argument(

--- a/experiments/doc_retriever.py
+++ b/experiments/doc_retriever.py
@@ -3,7 +3,8 @@
 import argparse
 from haystack.utils import print_documents
 from haystack.pipelines import DocumentSearchPipeline
-from haystack.document_stores import ElasticsearchDocumentStore
+
+# from haystack.document_stores import ElasticsearchDocumentStore
 from haystack.document_stores import InMemoryDocumentStore
 from haystack.nodes import BM25Retriever, TfidfRetriever, DensePassageRetriever
 
@@ -11,10 +12,47 @@ from .module import Dataset, DocRetriever, Sports, dataset_switch
 
 
 # Model setup
-NUM_K = 1  # 1, 3, 5, 10, 20
-DATASET = Dataset.SQuAD
-DOC_RETRIEVER = DocRetriever.BM25
-SPORT = Sports.ALL
+# NUM_K = 1  # 1, 3, 5, 10, 20
+# DATASET = Dataset.SQuAD
+# DOC_RETRIEVER = DocRetriever.BM25
+# SPORT = Sports.ALL
+parser = argparse.ArgumentParser(description="Run document retriever experiments.")
+parser.add_argument(
+    "--num_k",
+    type=int,
+    default=1,
+    help="Number of top-k documents to retrieve.",
+)
+parser.add_argument(
+    "--dataset",
+    type=str,
+    default="QASports",
+    choices=[attr.name for attr in Dataset],
+    help="Dataset to use for the experiment.",
+)
+parser.add_argument(
+    "--model",
+    type=str,
+    default="BM25",
+    choices=[attr.name for attr in DocRetriever],
+    help="Document retriever model to use.",
+)
+parser.add_argument(
+    "--sport",
+    type=str,
+    default="ALL",
+    choices=[attr.name for attr in Sports],
+    help="Sport to filter for QASports dataset.",
+)
+
+args = parser.parse_args()
+
+NUM_K = args.num_k
+DATASET = Dataset[args.dataset]
+DOC_RETRIEVER = DocRetriever[args.model]
+SPORT = Sports[args.sport].value
+print(f"Dataset: {DATASET} // Sport: {SPORT}")
+print(f"Model: {DOC_RETRIEVER} // Top-K: {NUM_K}")
 
 
 # Document Store
@@ -86,7 +124,7 @@ About the metrics, you can read the [evaluation](https://docs.haystack.deepset.a
 
 # For testing purposes, running on the first 100 labels
 # For real evaluation, you must remove the [0:100]
-eval_labels = dataset.get_validation()[0:10]
+eval_labels = dataset.get_validation()
 eval_result = pipe.eval(labels=eval_labels, params={"Retriever": {"top_k": NUM_K}})
 
 # Get and print the metrics

--- a/experiments/doc_retriever.py
+++ b/experiments/doc_retriever.py
@@ -1,0 +1,120 @@
+"""Document Retriever Experiments"""
+
+import argparse
+from haystack.utils import print_documents
+from haystack.pipelines import DocumentSearchPipeline
+from haystack.document_stores import ElasticsearchDocumentStore
+from haystack.document_stores import InMemoryDocumentStore
+from haystack.nodes import BM25Retriever, TfidfRetriever, DensePassageRetriever
+
+
+from .module import Dataset, DocRetriever, Sports
+from .module import (
+    SQuadDataset,
+    AdversarialQADataset,
+    DuoRCDataset,
+    QASportsDataset,
+)
+
+# run configuration
+NUM_K = 1  # 1, 3, 5, 10, 20
+DATASET = Dataset.SQuAD
+DOC_RETRIEVER = DocRetriever.BM25
+SPORT = Sports.ALL
+
+
+# Document Store
+# document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
+document_store = InMemoryDocumentStore()
+
+
+# Download the dataset
+def dataset_switch(choice):
+    """Get dataset class"""
+
+    if choice == Dataset.SQuAD:
+        return SQuadDataset()
+    elif choice == Dataset.AdvQA:
+        return AdversarialQADataset()
+    elif choice == Dataset.DuoRC:
+        return DuoRCDataset()
+    elif choice == Dataset.QASports:
+        return QASportsDataset()
+    else:
+        return "Invalid dataset"
+
+
+# Get the dataset
+dataset = dataset_switch(DATASET)
+
+# Store documents in the Document Store
+docs = dataset.get_documents()
+document_store.write_documents(docs)
+
+"""---
+## Document Retriever
+
+In this experiment, we explored the BM25, TF-IDF and Dense Passage Retrieval (DPR).
+
+* https://docs.haystack.deepset.ai/docs/retriever
+* https://github.com/facebookresearch/DPR
+* https://www.elastic.co/pt/blog/practical-bm25-part-2-the-bm25-algorithm-and-its-variables
+
+### Get the Retriever
+"""
+
+
+def retriever_switch(choice, document_store):
+    """Get Retriever object"""
+
+    if choice == DocRetriever.BM25:
+        retriever = BM25Retriever(document_store=document_store)
+        return retriever
+    elif choice == DocRetriever.TFIDF:
+        retriever = TfidfRetriever(document_store=document_store)
+        return retriever
+    elif choice == DocRetriever.DPR:
+        retriever = DensePassageRetriever(
+            document_store=document_store,
+            query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
+            passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
+            use_fast_tokenizers=True,
+        )
+        document_store.update_embeddings(retriever)
+        return retriever
+    else:
+        return "Invalid retriever"
+
+
+# Get the retriever
+retriever = retriever_switch(DOC_RETRIEVER, document_store)
+print(f"Retriever: {retriever}")
+
+
+"""### Build the Pipeline"""
+pipe = DocumentSearchPipeline(retriever=retriever)
+
+# Querying documents
+question = "What is your name?"
+prediction = pipe.run(query=question, params={"Retriever": {"top_k": 1}})
+
+# Print answer
+print_documents(prediction)
+
+"""---
+## Evaluation
+
+About the metrics, you can read the [evaluation](https://docs.haystack.deepset.ai/docs/evaluation) web page.
+"""
+
+# For testing purposes, running on the first 100 labels
+# For real evaluation, you must remove the [0:100]
+eval_labels = dataset.get_validation()[0:10]
+eval_result = pipe.eval(labels=eval_labels, params={"Retriever": {"top_k": NUM_K}})
+
+# Get and print the metrics
+metrics = eval_result.calculate_metrics()
+print(metrics)
+
+# Print a detailed report
+pipe.print_eval_report(eval_result)

--- a/experiments/doc_retriever.py
+++ b/experiments/doc_retriever.py
@@ -7,16 +7,10 @@ from haystack.document_stores import ElasticsearchDocumentStore
 from haystack.document_stores import InMemoryDocumentStore
 from haystack.nodes import BM25Retriever, TfidfRetriever, DensePassageRetriever
 
+from .module import Dataset, DocRetriever, Sports, dataset_switch
 
-from .module import Dataset, DocRetriever, Sports
-from .module import (
-    SQuadDataset,
-    AdversarialQADataset,
-    DuoRCDataset,
-    QASportsDataset,
-)
 
-# run configuration
+# Model setup
 NUM_K = 1  # 1, 3, 5, 10, 20
 DATASET = Dataset.SQuAD
 DOC_RETRIEVER = DocRetriever.BM25
@@ -25,27 +19,10 @@ SPORT = Sports.ALL
 
 # Document Store
 # document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
-document_store = InMemoryDocumentStore()
-
-
-# Download the dataset
-def dataset_switch(choice):
-    """Get dataset class"""
-
-    if choice == Dataset.SQuAD:
-        return SQuadDataset()
-    elif choice == Dataset.AdvQA:
-        return AdversarialQADataset()
-    elif choice == Dataset.DuoRC:
-        return DuoRCDataset()
-    elif choice == Dataset.QASports:
-        return QASportsDataset()
-    else:
-        return "Invalid dataset"
-
+document_store = InMemoryDocumentStore(use_bm25=True)
 
 # Get the dataset
-dataset = dataset_switch(DATASET)
+dataset = dataset_switch(DATASET, SPORT)
 
 # Store documents in the Document Store
 docs = dataset.get_documents()
@@ -94,12 +71,12 @@ print(f"Retriever: {retriever}")
 """### Build the Pipeline"""
 pipe = DocumentSearchPipeline(retriever=retriever)
 
-# Querying documents
-question = "What is your name?"
-prediction = pipe.run(query=question, params={"Retriever": {"top_k": 1}})
+# # Querying documents
+# question = "What is your name?"
+# prediction = pipe.run(query=question, params={"Retriever": {"top_k": 1}})
 
-# Print answer
-print_documents(prediction)
+# # Print answer
+# print_documents(prediction)
 
 """---
 ## Evaluation
@@ -115,6 +92,3 @@ eval_result = pipe.eval(labels=eval_labels, params={"Retriever": {"top_k": NUM_K
 # Get and print the metrics
 metrics = eval_result.calculate_metrics()
 print(metrics)
-
-# Print a detailed report
-pipe.print_eval_report(eval_result)

--- a/experiments/module.py
+++ b/experiments/module.py
@@ -266,3 +266,18 @@ class QASportsDataset(SQuadDataset):
     def _get_answers(self, data):
         # Get question answer
         return [data["answer"]["text"]]
+
+
+def dataset_switch(choice, sport):
+    """Get dataset class"""
+
+    if choice == Dataset.SQuAD:
+        return SQuadDataset()
+    elif choice == Dataset.AdvQA:
+        return AdversarialQADataset()
+    elif choice == Dataset.DuoRC:
+        return DuoRCDataset()
+    elif choice == Dataset.QASports:
+        return QASportsDataset(sport)
+    else:
+        return "Invalid dataset"

--- a/experiments/module.py
+++ b/experiments/module.py
@@ -24,6 +24,14 @@ class Dataset(enum.Enum):
     QASports = 4
 
 
+class DocRetriever(enum.Enum):
+    """Document Retriever options"""
+
+    BM25 = 1
+    TFIDF = 2
+    DPR = 3
+
+
 class DocReader(str, enum.Enum):
     """Document Reader options"""
 


### PR DESCRIPTION
## feat(experiments): Add document retriever experiments

This pull request introduces a new experiment script to evaluate and compare different document retrieval models. This complements the existing document reader experiments by allowing us to benchmark the first crucial stage of a modern Question Answering pipeline: finding relevant documents from a large corpus.

The new script leverages the Haystack framework to test various retrieval algorithms like BM25, TF-IDF, and Dense Passage Retriever (DPR) against our datasets.

### Key Changes:

*   **New Document Retriever Experiment**:
    *   Adds `experiments/doc_retriever.py`, a new script dedicated to running document retrieval evaluations.
    *   It builds a Haystack `DocumentSearchPipeline` to measure the performance of different retrievers.

*   **Supported Retriever Models**:
    *   A `retriever_switch` function has been implemented to easily select between:
        *   `BM25Retriever`
        *   `TfidfRetriever`
        *   `DensePassageRetriever` (DPR)

*   **Dynamic Configuration with Argparse**:
    *   The script integrates `argparse` to allow for flexible configuration from the command line. Users can now specify:
        *   `--model`: The retriever model to use (e.g., `BM25`, `DPR`).
        *   `--dataset`: The dataset for evaluation (e.g., `QASports`, `SQuAD`).
        *   `--sport`: The specific sport for the `QASports` dataset.
        *   `--num_k`: The number of top documents to retrieve.

*   **Refactoring**:
    *   The `dataset_switch` function in `experiments/module.py` was refactored for better clarity and to seamlessly support both the document reader and the new document retriever experiments.

### How to Run the New Experiment:

The `README.md` has been updated with instructions. You can run the experiment as follows:

```sh
# See all available options for the document retriever experiment
$ uv run -m experiments.doc_retriever --help

# Example: Run with the BM25 model on the QASports basketball dataset, retrieving the top 5 documents
$ uv run -m experiments.doc_retriever --model BM25 --dataset QASports --sport BASKETBALL --num_k 5
```

## Local Tests

```sh
➜  qasports-dataset-scripts git:(feat/add-doc-retriever) ✗ uv run -m experiments.doc_retriever --num_k 3 --dataset SQuAD --model DPR  
Dataset: Dataset.SQuAD // Sport: all
Model: DocRetriever.DPR // Top-K: 3
## SQuaD Dataset ##
Dataset({
    features: ['id', 'title', 'context', 'question', 'answers'],
    num_rows: 10570
})
Updating BM25 representation...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 26588.30 docs/s]
Documents Processed: 10000 docs [00:27, 360.40 docs/s]                                                                                                                                           
Retriever: <haystack.nodes.retriever.dense.DensePassageRetriever object at 0x744ab9e85090>                                                                                                       
{'Retriever': {'recall_multi_hit': 0.6666666666666666, 'recall_single_hit': 0.6666666666666666, 'precision': 0.2777777777777778, 'map': 0.8611111111111112, 'mrr': 0.6666666666666666, 'ndcg': 0.7347941325294953}}

➜  qasports-dataset-scripts git:(feat/add-doc-retriever) ✗ uv run -m experiments.doc_retriever --num_k 3 --dataset SQuAD --model TFIDF
Dataset: Dataset.SQuAD // Sport: all
Model: DocRetriever.TFIDF // Top-K: 3
## SQuaD Dataset ##
Dataset({
    features: ['id', 'title', 'context', 'question', 'answers'],
    num_rows: 10570
})
Updating BM25 representation...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 25522.11 docs/s]
Retriever: <haystack.nodes.retriever.sparse.TfidfRetriever object at 0x7be429d9c5e0>
{'Retriever': {'recall_multi_hit': 0.5555555555555556, 'recall_single_hit': 0.5555555555555556, 'precision': 0.18518518518518517, 'map': 0.42592592592592593, 'mrr': 0.42592592592592593, 'ndcg': 0.45899219484127307}}

➜  qasports-dataset-scripts git:(feat/add-doc-retriever) ✗ uv run -m experiments.doc_retriever --num_k 3 --dataset SQuAD --model BM25 
Dataset: Dataset.SQuAD // Sport: all
Model: DocRetriever.BM25 // Top-K: 3
## SQuaD Dataset ##
Dataset({
    features: ['id', 'title', 'context', 'question', 'answers'],
    num_rows: 10570
})
Updating BM25 representation...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 25452.42 docs/s]
Retriever: <haystack.nodes.retriever.sparse.BM25Retriever object at 0x7f06f26828c0>
{'Retriever': {'recall_multi_hit': 0.8148148148148148, 'recall_single_hit': 0.8888888888888888, 'precision': 0.35185185185185186, 'map': 0.7037037037037037, 'mrr': 0.6481481481481481, 'ndcg': 0.7141124071708137}}
```